### PR TITLE
docs(migration): mark qdrant slice as done

### DIFF
--- a/docs/benchmarks/data/weekly/2026-W08.md
+++ b/docs/benchmarks/data/weekly/2026-W08.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-- Current local status: pre-nightly dry run completed.
-- Release gate status: pending nightly evidence URL.
+- Current local status: benchmark dry run completed.
+- Nightly gate status: passed.
 
 ## Qdrant Snapshot (Local)
 
@@ -13,5 +13,5 @@
 
 ## Remaining Gate Inputs
 
-- Nightly benchmark workflow URL
-- Migration-unblocked issue URL and closure confirmation
+- Nightly benchmark workflow URL: https://github.com/wesichain/wesichain/actions/runs/22054138510
+- Migration-unblocked issue closure: https://github.com/wesichain/wesichain/issues/23

--- a/docs/migration/scoreboard.md
+++ b/docs/migration/scoreboard.md
@@ -4,13 +4,13 @@
 
 | Connector | Status | Guide | Example | Parity Test | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Qdrant | WIP | [langchain-to-wesichain-qdrant.md](./langchain-to-wesichain-qdrant.md) | [`wesichain-qdrant/examples/rag_integration.rs`](../../wesichain-qdrant/examples/rag_integration.rs) | [`wesichain-qdrant/tests/migration_parity.rs`](../../wesichain-qdrant/tests/migration_parity.rs) | Migration + benchmark artifacts are in place; waiting for nightly evidence and issue closure to mark DONE. |
+| Qdrant | DONE | [langchain-to-wesichain-qdrant.md](./langchain-to-wesichain-qdrant.md) | [`wesichain-qdrant/examples/rag_integration.rs`](../../wesichain-qdrant/examples/rag_integration.rs) | [`wesichain-qdrant/tests/migration_parity.rs`](../../wesichain-qdrant/tests/migration_parity.rs) | Migration artifacts validated; nightly gate passed and migration-unblocked issue closed. |
 
-## Qdrant Artifact Checklist (WIP)
+## Qdrant Artifact Checklist (DONE)
 
 - [x] Migration guide drafted: [langchain-to-wesichain-qdrant.md](./langchain-to-wesichain-qdrant.md)
 - [x] Runnable example present: [`wesichain-qdrant/examples/rag_integration.rs`](../../wesichain-qdrant/examples/rag_integration.rs)
 - [x] Deterministic parity test present: [`wesichain-qdrant/tests/migration_parity.rs`](../../wesichain-qdrant/tests/migration_parity.rs)
 - [x] Benchmark report placeholder: [`docs/benchmarks/data/qdrant-2026-02-16.json`](../benchmarks/data/qdrant-2026-02-16.json)
-- [ ] Nightly gate evidence placeholder: `<nightly-build-url>`
-- [ ] Migration-unblocked issue closure placeholder: `<issue-url>`
+- [x] Nightly gate evidence: [Nightly Benchmarks run 22054138510](https://github.com/wesichain/wesichain/actions/runs/22054138510)
+- [x] Migration-unblocked issue closure: [Issue #23](https://github.com/wesichain/wesichain/issues/23)


### PR DESCRIPTION
## Summary
- mark Qdrant row as DONE in migration scoreboard
- replace nightly and migration-unblocked placeholders with concrete evidence links
- update weekly benchmark rollup status to passed with linked evidence

## Validation
- python3 tools/bench/check_release_readiness.py --slice qdrant
- cargo test -p wesichain --test ci_config_validation -- --nocapture