### PR TITLE
chore(docs): add README claim guard check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,6 +7,14 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  docs-claims:
+    name: Docs Claims Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate README claims and versions
+        run: python3 tools/ci/check_docs_claims.py
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/tools/ci/check_docs_claims.py
+++ b/tools/ci/check_docs_claims.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Guard against stale README version and claim drift."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> int:
+    readme = Path("README.md")
+    if not readme.exists():
+        print("error: README.md not found")
+        return 2
+
+    text = readme.read_text(encoding="utf-8")
+
+    failures: list[str] = []
+
+    banned_tokens = [
+        "0.1.0",
+        '"0.2.0"',
+    ]
+    for token in banned_tokens:
+        if token in text:
+            failures.append(f"README contains banned token: {token}")
+
+    required_tokens = [
+        "v0.2.1",
+        "ReActGraphBuilder",
+        "wesichain-memory",
+    ]
+    for token in required_tokens:
+        if token not in text:
+            failures.append(f"README missing required token: {token}")
+
+    if failures:
+        print("docs claim guard failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("docs claim guard passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `tools/ci/check_docs_claims.py` to detect stale README version tokens and missing required runtime references
- add a `Docs Claims Guard` job to `.github/workflows/pr-checks.yml` so PRs fail early when README claims drift
- keep checks lightweight and local to docs metadata validation

## Verification
- `python3 tools/ci/check_docs_claims.py`

## AI Disclosure
- This PR was prepared with AI assistance.